### PR TITLE
Adds a shields.io version badge to the `README.md` file to display th…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # HmCustomRenderBrowser
 
 [![CC0](https://img.shields.io/badge/license-CC0-blue.svg?style=flat)](LICENSE.txt)
+[![version](https://img.shields.io/badge/version-2.4.4.2-blue.svg?style=flat)](HmCustomRenderServer.js)
 
 秀丸エディタのコンテンツをブラウザペインに表示し、Web技術（HTML/CSS/JS）で自由にレンダリングするためのフレームワークです。
 


### PR DESCRIPTION
…e application version.

The version number `2.4.4.2` is sourced from a comment in the `HmCustomRenderServer.js` file. A static badge was used because the project does not contain a standard versioning file like `package.json` or use git tags for releases.

The badge links to `HmCustomRenderServer.js` to provide context for the displayed version. While a dynamic badge would be preferable, this approach avoids introducing new project files or versioning systems and directly addresses the user's request.